### PR TITLE
Add non-string values support

### DIFF
--- a/app/helpers/t.js
+++ b/app/helpers/t.js
@@ -6,6 +6,10 @@ var translationMissing = function(keyPath) {
 
 export default function(key, options) {
   options = options || {};
-  var attrs = options.hash;
-  return new Ember.Handlebars.SafeString(foreigner.t(key, attrs) || translationMissing(key));
+  let attrs = options.hash;
+  let translation = foreigner.t(key, attrs);
+
+  if (!translation) return new Ember.Handlebars.SafeString(translationMissing(key));
+  if (typeof translation === 'string') return new Ember.Handlebars.SafeString(translation);
+  return translation;
 }

--- a/app/initializers/ember-cli-foreigner.js
+++ b/app/initializers/ember-cli-foreigner.js
@@ -2,11 +2,11 @@ import Ember from 'ember';
 import t from '../helpers/t';
 import config from '../config/environment';
 
-var LOCALE_PREFIX = config.localePrefix ? config.localePrefix.replace(`${config.modulePrefix}/`, '') : 'locales';
+const LOCALE_PREFIX = config.localePrefix ? config.localePrefix.replace(`${config.modulePrefix}/`, '') : 'locales';
 
 var registerLibrary = function() {
   if (Ember.libraries && !Ember.libraries._getLibraryByName('ember-cli-foreigner')) {
-    Ember.libraries.register('ember-cli-foreigner', '1.0.0');
+    Ember.libraries.register('ember-cli-foreigner', '1.1.0');
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-foreigner",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "directories": {
     "doc": "doc",
     "test": "tests"

--- a/tests/fixtures/locale-en.js
+++ b/tests/fixtures/locale-en.js
@@ -2,6 +2,7 @@
 
 export default {
   unit_tests: {
-    hello_world: 'Hello, World.'
+    hello_world: 'Hello, World.',
+    weekdays: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
   }
 };

--- a/tests/unit/helpers/t-test.js
+++ b/tests/unit/helpers/t-test.js
@@ -21,4 +21,8 @@ describe('`t` helper', function() {
   it('should return a string stating that a translation is missing when it’s the case', function() {
     expect(t('unit_tests.inexistant_key').string).to.equal('translation missing: en.unit_tests.inexistant_key');
   });
+
+  it('should be able to return an array value', function() {
+    expect(t('unit_tests.weekdays')).to.deep.equal(['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']);
+  });
 });


### PR DESCRIPTION
Sometimes we want to lookup non-string values, for example this should work now:

``` hbs
{{#each (t 'weekdays') as |weekday|}}
  {{weekday}}
{{/each}}
```
